### PR TITLE
Fixing clean cache method

### DIFF
--- a/src/Cache/CacheWriter.php
+++ b/src/Cache/CacheWriter.php
@@ -96,6 +96,6 @@ class CacheWriter
      */
     public function clean()
     {
-        $this->write('<?php', null);
+        $this->write("<?php\n", null);
     }
 }


### PR DESCRIPTION
Added a newline so PHP will parse correctly on an empty cache file. This
resolves #2.

Signed-off-by: Nate Brunette n@tebru.net
