### PR TITLE
Fix project tool binaries.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /.idea
 /vendor
-/bin/composer.phar
+/bin
+!/bin/composer
+!/bin/retrofit
 /cache
 *.iml
 /build

--- a/bin/composer
+++ b/bin/composer
@@ -15,7 +15,7 @@
  * @author Maxwell Vandervelde <Max@MaxVandervelde.com>
  */
 $composerExecutable = __DIR__ . '/composer.phar';
-$composerUrl = 'https://getcomposer.org/download/1.0.0-alpha9/composer.phar';
+$composerUrl = 'https://getcomposer.org/download/1.0.0-alpha10/composer.phar';
 if (false === file_exists($composerExecutable)) {
     $fileName = basename($composerExecutable);
     echo "> $fileName not found, attempting to download...\r\n";

--- a/composer.json
+++ b/composer.json
@@ -31,5 +31,8 @@
             "Tebru\\Retrofit\\Test\\": "tests/"
         }
     },
-    "bin": ["bin/retrofit"]
+    "bin": ["bin/retrofit"],
+    "config": {
+        "bin-dir": "bin"
+    }
 }


### PR DESCRIPTION
Updated composer-wrapper to alpha-10 (required by config)
fixed bin directory of 3rd party tools such as phpunit so they can be
executed by calling `bin/phpunit`

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | n/a |
