### PR TITLE
Optimize Autoloader

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,7 +5,10 @@ This is a credits file of people that have contributed Retrofit-PHP Library.
 
  * Nate Brunette
    * Email: n@tebru.net
-   
+
  * Maxwell Vandervelde
    * Email: Max@MaxVandervelde.com
    * PGP: `4096R/2B95C590 C21D 81E7 1F58 6C96 955F 5141 444C 4178 2B95 C590`
+
+ * Matthew Loberg
+   * Email: loberg.matt@gmail.com

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,11 @@
     ],
     "autoload": {
         "psr-4": {
-            "Tebru\\Retrofit\\": "src/",
+            "Tebru\\Retrofit\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
             "Tebru\\Retrofit\\Test\\": "tests/"
         }
     },


### PR DESCRIPTION
Composer has an autoload-dev option that can have additional autoload paths for when dev mode is used (just like require-dev). This should optimize the autoloader by not having the tests path loaded when using the library normally.
