### PR TITLE
Change return type from `null` to `void`

### DIFF
--- a/src/Generation/Listener/DynamoStartListener.php
+++ b/src/Generation/Listener/DynamoStartListener.php
@@ -91,14 +91,14 @@ class DynamoStartListener
      * Create wait method
      *
      * @param ClassModel $classModel
-     * @return null
+     * @return void
      */
     private function addWait(ClassModel $classModel)
     {
         $reflectionClass = new \ReflectionClass($classModel->getInterface());
 
         if (!in_array('Tebru\Retrofit\Http\AsyncAware', $reflectionClass->getInterfaceNames())) {
-            return null;
+            return;
         }
 
         $methodModel = new MethodModel($classModel, 'wait');


### PR DESCRIPTION
While there isn't a technical difference between the two, to me, there's a fundamental difference between returning `null` and returning `void`. In this case, returning `void` is the more appropriate return type.
