### PR TITLE
Use `ReflectionNamedType::getName` instead of casting the type to `string`

### DIFF
--- a/src/Internal/DefaultProxyFactory.php
+++ b/src/Internal/DefaultProxyFactory.php
@@ -166,7 +166,7 @@ final class DefaultProxyFactory implements ProxyFactory
                     ));
                 }
 
-                $reflectionTypeName = (string)$reflectionParameter->getType();
+                $reflectionTypeName = $reflectionParameter->getType()->getName();
                 if ((new TypeToken($reflectionTypeName))->isObject()) {
                     $reflectionTypeName = '\\'.$reflectionTypeName;
                 }


### PR DESCRIPTION
Because the string casting is deprecated since PHP 7.4.

As this project has PHP 7.1 as minimum and [ReflectionNamedType::getName](https://www.php.net/manual/de/reflectionnamedtype.getname.php) exists since PHP 7.1 it can safely be used.

Fixes #81 