### PR TITLE
chore(deps): symfony/console 5.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "guzzlehttp/psr7": "^1.0",
         "nikic/php-parser": "~3.0.6|^4.0",
         "symfony/cache": "^3.3|^4.0|^5.0",
-        "symfony/console": "^3.0|^4.0",
+        "symfony/console": "^3.0|^4.0|^5.0",
         "tebru/doctrine-annotation-reader": "^0.3.0",
         "tebru/php-type": "^0.1.1"
     },


### PR DESCRIPTION
package `symfony/console` can be safely updated to version 5.x