### PR TITLE
Require PHP 8, Symfony 5.4, PHPUnit 9.3. Allow Symfony 6.

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,17 @@
+build:
+    nodes:
+        my-tests:
+            environment:
+                php:
+                    version: 8.1
+            tests:
+                override:
+                    - phpcs-run
+                    -
+                        command: 'XDEBUG_MODE=coverage vendor/bin/phpunit'
+                        coverage:
+                            file: 'build/logs/clover.xml'
+                            format: 'clover'
+filter:
+    excluded_paths:
+        - 'tests/*'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,22 @@
-sudo: false
+dist: xenial
+
+os: linux
 
 language: php
+
 php:
-  - 7.1
-  - 7.2
-  - 7.3
-  - 7.4
+  - 8.0
+  - 8.1
 
 env:
-  - SF_CACHE=3
-  - SF_CACHE=4
-  - SF_CACHE=4.3
-  - SF_CACHE=5
-
-jobs:
-  exclude:
-    - php: 7.1
-      env:
-        - SF_CACHE=5
+  - SYMFONY=5
+  - SYMFONY=6
 
 # remove composer.lock (it should not be published)
 before_script:
   - composer install --no-interaction -o
-  - if [ "$SF_CACHE" = "3" ]; then composer require symfony/cache:^3.3; fi;
-  - if [ "$SF_CACHE" = "4" ]; then composer require symfony/cache:">=4.0 <4.3"; fi;
-  - if [ "$SF_CACHE" = "4.3" ]; then composer require symfony/cache:^4.3; fi;
-  - if [ "$SF_CACHE" = "5" ]; then composer require symfony/cache:5.0; fi;
+  - if [ "$SYMFONY" = "5" ]; then composer update --with=symfony/cache:^5.4 --with=symfony/console:^5.4; fi;
+  - if [ "$SYMFONY" = "6" ]; then composer update --with=symfony/cache:^6.0 --with=symfony/console:^6.0; fi;
 
 script:
   - mkdir -p build/logs

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ $responseBody = $response->body();
 Installation & Usage
 --------------------
 
-*Retrofit 3 requires PHP 7.1*
+*Retrofit 3 requires PHP 8.0*
 
 ```bash
 composer require tebru/retrofit-php

--- a/composer.json
+++ b/composer.json
@@ -2,16 +2,16 @@
     "name": "tebru/retrofit-php",
     "description": "Retrofit for PHP - A type-safe PHP REST client.",
     "require": {
-        "php": ">= 7.1",
+        "php": ">= 8.0",
         "guzzlehttp/psr7": "^1.0",
         "nikic/php-parser": "~3.0.6|^4.0",
-        "symfony/cache": "^3.3|^4.0|^5.0",
-        "symfony/console": "^3.0|^4.0|^5.0",
+        "symfony/cache": "^5.4|^6.0",
+        "symfony/console": "^5.4|^6.0",
         "tebru/doctrine-annotation-reader": "^0.3.0",
         "tebru/php-type": "^0.1.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.3",
+        "phpunit/phpunit": "^9.3",
         "mikey179/vfsstream": "^1.6"
     },
     "license": "MIT",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,16 +1,18 @@
-<phpunit colors="true" bootstrap="tests/bootstrap.php">
-    <testsuites>
-        <testsuite name="Unit">
-            <directory>tests/Unit</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory>src</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-        <log type="coverage-html" target="build/logs/html"/>
-    </logging>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" bootstrap="tests/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory>src</directory>
+    </include>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+      <html outputDirectory="build/logs/html"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Unit">
+      <directory>tests/Unit</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/src/Internal/ServiceMethod/DefaultServiceMethodBuilder.php
+++ b/src/Internal/ServiceMethod/DefaultServiceMethodBuilder.php
@@ -319,7 +319,7 @@ final class DefaultServiceMethodBuilder implements ServiceMethodBuilder
 
         if ($this->path === null) {
             throw new LogicException(
-                'Retrofit: Cannot build service method without HTTP method. Please specify @GET, @POST, etc'
+                'Retrofit: Cannot build service method without path. Please specify on RetrofitBuilder'
             );
         }
 

--- a/tests/LegacyAttributeTestFunctionsTrait.php
+++ b/tests/LegacyAttributeTestFunctionsTrait.php
@@ -1,0 +1,270 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tebru\Retrofit\Test;
+
+use PHPUnit\Framework\Exception;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\InvalidArgumentException;
+use ReflectionClass;
+use ReflectionException;
+use ReflectionObject;
+
+/**
+ * Pulled from PHPUnit v8.5.33 before they were removed in v9.
+ */
+trait LegacyAttributeTestFunctionsTrait
+{
+    /**
+     * Asserts that a variable and an attribute of an object have the same type
+     * and value.
+     *
+     * @param object|string $actualClassOrObject
+     *
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws Exception
+     * @throws ExpectationFailedException
+     *
+     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/3338
+     *
+     * @codeCoverageIgnore
+     */
+    public static function assertAttributeSame($expected, string $actualAttributeName, $actualClassOrObject, string $message = ''): void
+    {
+        static::assertSame(
+            $expected,
+            static::readAttribute($actualClassOrObject, $actualAttributeName),
+            $message
+        );
+    }
+
+    /**
+     * Asserts that a variable is equal to an attribute of an object.
+     *
+     * @param object|string $actualClassOrObject
+     *
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws Exception
+     * @throws ExpectationFailedException
+     *
+     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/3338
+     *
+     * @codeCoverageIgnore
+     */
+    public static function assertAttributeEquals($expected, string $actualAttributeName, $actualClassOrObject, string $message = '', float $delta = 0.0, int $maxDepth = 10, bool $canonicalize = false, bool $ignoreCase = false): void
+    {
+        static::assertEquals(
+            $expected,
+            static::readAttribute($actualClassOrObject, $actualAttributeName),
+            $message,
+            $delta,
+            $maxDepth,
+            $canonicalize,
+            $ignoreCase
+        );
+    }
+
+    /**
+     * Asserts that a variable is not equal to an attribute of an object.
+     *
+     * @param object|string $actualClassOrObject
+     *
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws Exception
+     * @throws ExpectationFailedException
+     *
+     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/3338
+     *
+     * @codeCoverageIgnore
+     */
+    public static function assertAttributeNotEquals($expected, string $actualAttributeName, $actualClassOrObject, string $message = '', float $delta = 0.0, int $maxDepth = 10, bool $canonicalize = false, bool $ignoreCase = false): void
+    {
+        static::assertNotEquals(
+            $expected,
+            static::readAttribute($actualClassOrObject, $actualAttributeName),
+            $message,
+            $delta,
+            $maxDepth,
+            $canonicalize,
+            $ignoreCase
+        );
+    }
+
+    /**
+     * Asserts the number of elements of an array, Countable or Traversable
+     * that is stored in an attribute.
+     *
+     * @param object|string $haystackClassOrObject
+     *
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws Exception
+     * @throws ExpectationFailedException
+     *
+     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/3338
+     *
+     * @codeCoverageIgnore
+     */
+    public static function assertAttributeCount(int $expectedCount, string $haystackAttributeName, $haystackClassOrObject, string $message = ''): void
+    {
+        static::assertCount(
+            $expectedCount,
+            static::readAttribute($haystackClassOrObject, $haystackAttributeName),
+            $message
+        );
+    }
+
+    /**
+     * Returns the value of an attribute of a class or an object.
+     * This also works for attributes that are declared protected or private.
+     *
+     * @param object|string $classOrObject
+     *
+     * @throws Exception
+     *
+     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/3338
+     *
+     * @codeCoverageIgnore
+     */
+    public static function readAttribute($classOrObject, string $attributeName)
+    {
+        if (!self::isValidClassAttributeName($attributeName)) {
+            throw InvalidArgumentException::create(2, 'valid attribute name');
+        }
+
+        if (is_string($classOrObject)) {
+            if (!class_exists($classOrObject)) {
+                throw InvalidArgumentException::create(
+                    1,
+                    'class name'
+                );
+            }
+
+            return static::getStaticAttribute(
+                $classOrObject,
+                $attributeName
+            );
+        }
+
+        if (is_object($classOrObject)) {
+            return static::getObjectAttribute(
+                $classOrObject,
+                $attributeName
+            );
+        }
+
+        throw InvalidArgumentException::create(
+            1,
+            'class name or object'
+        );
+    }
+
+    /**
+     * Returns the value of a static attribute.
+     * This also works for attributes that are declared protected or private.
+     *
+     * @throws Exception
+     *
+     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/3338
+     *
+     * @codeCoverageIgnore
+     */
+    public static function getStaticAttribute(string $className, string $attributeName)
+    {
+        if (!class_exists($className)) {
+            throw InvalidArgumentException::create(1, 'class name');
+        }
+
+        if (!self::isValidClassAttributeName($attributeName)) {
+            throw InvalidArgumentException::create(2, 'valid attribute name');
+        }
+
+        try {
+            $class = new ReflectionClass($className);
+            // @codeCoverageIgnoreStart
+        } catch (ReflectionException $e) {
+            throw new Exception(
+                $e->getMessage(),
+                $e->getCode(),
+                $e
+            );
+        }
+        // @codeCoverageIgnoreEnd
+
+        while ($class) {
+            $attributes = $class->getStaticProperties();
+
+            if (array_key_exists($attributeName, $attributes)) {
+                return $attributes[$attributeName];
+            }
+
+            $class = $class->getParentClass();
+        }
+
+        throw new Exception(
+            sprintf(
+                'Attribute "%s" not found in class.',
+                $attributeName
+            )
+        );
+    }
+
+    /**
+     * Returns the value of an object's attribute.
+     * This also works for attributes that are declared protected or private.
+     *
+     * @param object $object
+     *
+     * @throws Exception
+     *
+     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/3338
+     *
+     * @codeCoverageIgnore
+     */
+    public static function getObjectAttribute($object, string $attributeName)
+    {
+        if (!is_object($object)) {
+            throw InvalidArgumentException::create(1, 'object');
+        }
+
+        if (!self::isValidClassAttributeName($attributeName)) {
+            throw InvalidArgumentException::create(2, 'valid attribute name');
+        }
+
+        $reflector = new ReflectionObject($object);
+
+        do {
+            try {
+                $attribute = $reflector->getProperty($attributeName);
+
+                if (!$attribute || $attribute->isPublic()) {
+                    return $object->{$attributeName};
+                }
+
+                $attribute->setAccessible(true);
+                $value = $attribute->getValue($object);
+                $attribute->setAccessible(false);
+
+                return $value;
+            } catch (ReflectionException $e) {
+            }
+        } while ($reflector = $reflector->getParentClass());
+
+        throw new Exception(
+            sprintf(
+                'Attribute "%s" not found in object.',
+                $attributeName
+            )
+        );
+    }
+
+    private static function isValidObjectAttributeName(string $attributeName): bool
+    {
+        return (bool) preg_match('/[^\x00-\x1f\x7f-\x9f]+/', $attributeName);
+    }
+
+    private static function isValidClassAttributeName(string $attributeName): bool
+    {
+        return (bool) preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName);
+    }
+}

--- a/tests/Mock/Unit/RetrofitTest/ApiClient.php
+++ b/tests/Mock/Unit/RetrofitTest/ApiClient.php
@@ -60,9 +60,9 @@ interface ApiClient
      * @Headers({
      *     "X-Foo: bar",
      *     "X-Baz: qux",
-     *     "X-Header[]: first"
+     *     "X-Header: first"
      * })
-     * @Header("X-Header[]", var="header1")
+     * @Header("X-Header", var="header1")
      * @Header("header2")
      * @HeaderMap("headerMap")
      */

--- a/tests/Unit/Internal/AnnotationHandlersTest.php
+++ b/tests/Unit/Internal/AnnotationHandlersTest.php
@@ -57,9 +57,12 @@ use Tebru\Retrofit\Internal\ParameterHandler\UrlParamHandler;
 use Tebru\Retrofit\RequestBodyConverter;
 use Tebru\Retrofit\ServiceMethodBuilder;
 use Tebru\Retrofit\StringConverter;
+use Tebru\Retrofit\Test\LegacyAttributeTestFunctionsTrait;
 
 class AnnotationHandlersTest extends TestCase
 {
+    use LegacyAttributeTestFunctionsTrait;
+
     /**
      * @var ServiceMethodBuilder
      */
@@ -75,7 +78,7 @@ class AnnotationHandlersTest extends TestCase
      */
     private $stringConverter;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->serviceMethodBuilder = new DefaultServiceMethodBuilder();
         $this->requestBodyConverter = new DefaultRequestBodyConverter();

--- a/tests/Unit/Internal/AnnotationProcessorTest.php
+++ b/tests/Unit/Internal/AnnotationProcessorTest.php
@@ -26,11 +26,14 @@ use Tebru\Retrofit\Internal\Converter\DefaultStringConverter;
 use Tebru\Retrofit\Internal\ParameterHandler\BodyParamHandler;
 use Tebru\Retrofit\Internal\ParameterHandler\QueryParamHandler;
 use Tebru\Retrofit\ServiceMethodBuilder;
+use Tebru\Retrofit\Test\LegacyAttributeTestFunctionsTrait;
 use Tebru\Retrofit\Test\Mock\Unit\Internal\AnnotationProcessorTest\AnnotationProcessorTestMock;
 use Tebru\Retrofit\Test\Mock\Unit\Internal\AnnotationProcessorTest\BadConverterAnnotation;
 
 class AnnotationProcessorTest extends TestCase
 {
+    use LegacyAttributeTestFunctionsTrait;
+
     /**
      * @var AnnotationProcessor
      */
@@ -46,7 +49,7 @@ class AnnotationProcessorTest extends TestCase
      */
     private $converterProvider;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->annotationProcessor = new AnnotationProcessor([
             Header::class => new HeadersAnnotHandler(),

--- a/tests/Unit/Internal/CallAdapterTest.php
+++ b/tests/Unit/Internal/CallAdapterTest.php
@@ -27,7 +27,7 @@ class CallAdapterTest extends TestCase
      */
     private $callAdapterProvider;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->callAdapterProvider = new CallAdapterProvider([new DefaultCallAdapterFactory()]);
     }

--- a/tests/Unit/Internal/ConverterTest.php
+++ b/tests/Unit/Internal/ConverterTest.php
@@ -29,7 +29,7 @@ class ConverterTest extends TestCase
      */
     private $converterProvider;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->converterProvider = new ConverterProvider([new DefaultConverterFactory()]);
     }

--- a/tests/Unit/Internal/DefaultProxyFactoryTest.php
+++ b/tests/Unit/Internal/DefaultProxyFactoryTest.php
@@ -11,6 +11,7 @@ use InvalidArgumentException;
 use LogicException;
 use PhpParser\BuilderFactory;
 use PhpParser\PrettyPrinter\Standard;
+use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use Tebru\AnnotationReader\AnnotationReaderAdapter;
 use Tebru\Retrofit\Internal\AnnotationProcessor;
@@ -20,7 +21,6 @@ use Tebru\Retrofit\Internal\CallAdapter\DefaultCallAdapterFactory;
 use Tebru\Retrofit\Internal\Converter\ConverterProvider;
 use Tebru\Retrofit\Internal\Converter\DefaultConverterFactory;
 use Tebru\Retrofit\Internal\DefaultProxyFactory;
-use PHPUnit\Framework\TestCase;
 use Tebru\Retrofit\Internal\ServiceMethod\ServiceMethodFactory;
 use Tebru\Retrofit\Test\Mock\Unit\Internal\ProxyFactoryTest\PFTCTestCreate;
 use Tebru\Retrofit\Test\Mock\Unit\Internal\ProxyFactoryTest\PFTCTestCreateCacheDirectoryFail;
@@ -39,7 +39,7 @@ class DefaultProxyFactoryTest extends TestCase
      */
     private $filesystem;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->filesystem = new ProxyFactoryTestFilesystem();
     }

--- a/tests/Unit/Internal/FilesystemTest.php
+++ b/tests/Unit/Internal/FilesystemTest.php
@@ -7,8 +7,8 @@
 namespace Tebru\Retrofit\Test\Unit\Internal;
 
 use org\bovigo\vfs\vfsStream;
-use Tebru\Retrofit\Internal\Filesystem;
 use PHPUnit\Framework\TestCase;
+use Tebru\Retrofit\Internal\Filesystem;
 
 class FilesystemTest extends TestCase
 {
@@ -17,7 +17,7 @@ class FilesystemTest extends TestCase
      */
     private $filesystem;
 
-    public function setUp()
+    public function setUp(): void
     {
         vfsStream::setup('cache');
         $this->filesystem = new Filesystem();

--- a/tests/Unit/Internal/HttpClientCallTest.php
+++ b/tests/Unit/Internal/HttpClientCallTest.php
@@ -8,11 +8,11 @@ namespace Tebru\Retrofit\Test\Unit\Internal;
 
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use Tebru\Retrofit\Exception\ResponseHandlingFailedException;
 use Tebru\Retrofit\Internal\HttpClientCall;
 use Tebru\Retrofit\Response as RetrofitResponse;
-use PHPUnit\Framework\TestCase;
 use Tebru\Retrofit\Test\Mock\Unit\Internal\HttpClientCallTest\HttpClientCallTestClientMock;
 use Tebru\Retrofit\Test\Mock\Unit\Internal\HttpClientCallTest\HttpClientCallTestErrorBodyMock;
 use Tebru\Retrofit\Test\Mock\Unit\Internal\HttpClientCallTest\HttpClientCallTestResponseBodyMock;

--- a/tests/Unit/Internal/ParameterHandlersTest.php
+++ b/tests/Unit/Internal/ParameterHandlersTest.php
@@ -29,6 +29,7 @@ use Tebru\Retrofit\Internal\ParameterHandler\QueryNameParamHandler;
 use Tebru\Retrofit\Internal\ParameterHandler\QueryParamHandler;
 use Tebru\Retrofit\Internal\ParameterHandler\UrlParamHandler;
 use Tebru\Retrofit\Internal\RequestBuilder;
+use Tebru\Retrofit\Test\LegacyAttributeTestFunctionsTrait;
 use function GuzzleHttp\Psr7\stream_for;
 
 /**
@@ -38,12 +39,14 @@ use function GuzzleHttp\Psr7\stream_for;
  */
 class ParameterHandlersTest extends TestCase
 {
+    use LegacyAttributeTestFunctionsTrait;
+
     /**
      * @var RequestBuilder
      */
     private $requestBuilder;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->requestBuilder = new RequestBuilder('GET', 'http://example.com', '/test/{path}?q=test', []);
     }

--- a/tests/Unit/Internal/RequestBuilderTest.php
+++ b/tests/Unit/Internal/RequestBuilderTest.php
@@ -8,8 +8,8 @@ namespace Tebru\Retrofit\Test\Unit\Internal;
 
 use GuzzleHttp\Psr7\AppendStream;
 use LogicException;
-use Tebru\Retrofit\Internal\RequestBuilder;
 use PHPUnit\Framework\TestCase;
+use Tebru\Retrofit\Internal\RequestBuilder;
 use function GuzzleHttp\Psr7\stream_for;
 
 class RequestBuilderTest extends TestCase

--- a/tests/Unit/Internal/ServiceMethod/DefaultServiceMethodBuilderTest.php
+++ b/tests/Unit/Internal/ServiceMethod/DefaultServiceMethodBuilderTest.php
@@ -16,15 +16,18 @@ use Tebru\Retrofit\Internal\ParameterHandler\FieldParamHandler;
 use Tebru\Retrofit\Internal\ParameterHandler\PartParamHandler;
 use Tebru\Retrofit\Internal\ServiceMethod\DefaultServiceMethodBuilder;
 use PHPUnit\Framework\TestCase;
+use Tebru\Retrofit\Test\LegacyAttributeTestFunctionsTrait;
 
 class DefaultServiceMethodBuilderTest extends TestCase
 {
+    use LegacyAttributeTestFunctionsTrait;
+
     /**
      * @var DefaultServiceMethodBuilder
      */
     private $serviceMethodBuilder;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->serviceMethodBuilder = new DefaultServiceMethodBuilder();
     }
@@ -199,7 +202,7 @@ class DefaultServiceMethodBuilderTest extends TestCase
             $this->serviceMethodBuilder->build();
         } catch (LogicException $exception) {
             self::assertSame(
-                'Retrofit: Cannot build service method without HTTP method. Please specify @GET, @POST, etc',
+                'Retrofit: Cannot build service method without path. Please specify on RetrofitBuilder',
                 $exception->getMessage()
             );
             return;

--- a/tests/Unit/Internal/ServiceMethod/ServiceMethodFactoryTest.php
+++ b/tests/Unit/Internal/ServiceMethod/ServiceMethodFactoryTest.php
@@ -22,17 +22,20 @@ use Tebru\Retrofit\Internal\Converter\DefaultConverterFactory;
 use Tebru\Retrofit\Internal\Converter\DefaultResponseBodyConverter;
 use Tebru\Retrofit\Internal\ServiceMethod\ServiceMethodFactory;
 use PHPUnit\Framework\TestCase;
+use Tebru\Retrofit\Test\LegacyAttributeTestFunctionsTrait;
 use Tebru\Retrofit\Test\Mock\Unit\Internal\ServiceMethod\ServiceMethodFactoryTest\ServiceMethodFactoryTestConverterFactory;
 use Tebru\Retrofit\Test\Mock\Unit\Internal\ServiceMethod\ServiceMethodFactoryTest\ServiceMethodFactoryTestClient;
 
 class ServiceMethodFactoryTest extends TestCase
 {
+    use LegacyAttributeTestFunctionsTrait;
+
     /**
      * @var ServiceMethodFactory
      */
     private $serviceMethodFactory;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->serviceMethodFactory = new ServiceMethodFactory(
             new AnnotationProcessor([

--- a/tests/Unit/Internal/ServiceMethod/ServiceMethodTest.php
+++ b/tests/Unit/Internal/ServiceMethod/ServiceMethodTest.php
@@ -10,12 +10,12 @@ use GuzzleHttp\Psr7\AppendStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use LogicException;
+use PHPUnit\Framework\TestCase;
 use Tebru\Retrofit\Internal\CallAdapter\DefaultCallAdapter;
 use Tebru\Retrofit\Internal\Converter\DefaultRequestBodyConverter;
 use Tebru\Retrofit\Internal\Converter\DefaultResponseBodyConverter;
 use Tebru\Retrofit\Internal\ParameterHandler\BodyParamHandler;
 use Tebru\Retrofit\Internal\ServiceMethod\DefaultServiceMethod;
-use PHPUnit\Framework\TestCase;
 use Tebru\Retrofit\Test\Mock\Unit\MockCall;
 
 class ServiceMethodTest extends TestCase
@@ -25,7 +25,7 @@ class ServiceMethodTest extends TestCase
      */
     private $serviceMethod;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->serviceMethod = new DefaultServiceMethod(
             'POST',

--- a/tests/Unit/RetrofitTest.php
+++ b/tests/Unit/RetrofitTest.php
@@ -6,6 +6,7 @@
 
 namespace Tebru\Retrofit\Test\Unit;
 
+use Doctrine\Common\Annotations\AnnotationException;
 use LogicException;
 use RuntimeException;
 use Tebru\Retrofit\Annotation\GET;
@@ -41,7 +42,7 @@ class RetrofitTest extends TestCase
      */
     private $retrofitBuilder;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->httpClient = new RetrofitTestHttpClient();
         $this->retrofitBuilder = Retrofit::builder()
@@ -102,7 +103,7 @@ class RetrofitTest extends TestCase
 
         $service
             ->headers(
-                ['X-Header[]' => ['one', 2, false]],
+                ['X-Header' => ['one', 2, false]],
                 [true, 3.14],
                 5
             )
@@ -120,7 +121,7 @@ class RetrofitTest extends TestCase
                 'Host' => ['example.com'],
                 'x-foo' => ['bar'],
                 'x-baz' => ['qux'],
-                'x-header[]' => ['first', 'one', '2', 'false', 'true', '3.14'],
+                'x-header' => ['first', 'one', '2', 'false', 'true', '3.14'],
                 'header2' => ['5']
             ],
             $request->getHeaders()
@@ -471,8 +472,11 @@ class RetrofitTest extends TestCase
 
         try {
             $service->get();
-        } catch (RuntimeException $exception) {
-            self::assertSame('Retrofit: Header in an incorrect format.  Expected "Name: value"', $exception->getMessage());
+        } catch (AnnotationException $exception) {
+            self::assertSame(
+                'Retrofit: Header in an incorrect format.  Expected "Name: value"',
+                $exception->getPrevious()->getMessage()
+            );
             return;
         }
 


### PR DESCRIPTION
This will allow us to install Retrofit on Symfony v5.4 and v6, with PHP v8, which are the only maintained versions.

I'll probably spend some time in the next couple months adding support for PHP 8 features to Retrofit and Gson. Can I at the same time drop support for PHP 7? Symfony dropped PHP 7 support in 2021.